### PR TITLE
Fft fix

### DIFF
--- a/dLux/propagators.py
+++ b/dLux/propagators.py
@@ -70,7 +70,7 @@ class FFT(Propagator):
 
     def __init__(
         self         : Propagator, 
-        focal_length : Array,
+        focal_length : Array = None,
         pad          : int = 2,
         inverse      : bool = False) -> Propagator:
         super().__init__(focal_length=focal_length, inverse=inverse)

--- a/dLux/wavefronts.py
+++ b/dLux/wavefronts.py
@@ -641,7 +641,8 @@ class Wavefront(Base):
     #############################
     ### Propagation Functions ###
     #############################
-    def _FFT_output(self         : Wavefront, 
+    def _FFT_output(self         : Wavefront,
+                    pad_factor   : int = 1,
                     focal_length : Array = None, 
                     inverse      : bool = False) -> tuple:
         """
@@ -665,12 +666,12 @@ class Wavefront(Base):
         pixel_scale : Array
             The pixel scale of the output plane.
         """
+        pixel_scale = self.fringe_size / pad_factor
         if focal_length is None:
             units = 'Angular'
-            pixel_scale =  self.wavelength / self.diameter
         else:
             units = 'Cartesian'
-            pixel_scale = focal_length * self.wavelength / self.diameter
+            pixel_scale *= focal_length
 
             # Check for invalid propagation
             if self.units == 'Angular':
@@ -739,7 +740,7 @@ class Wavefront(Base):
             The propagated wavefront.
         """
         # Calculate
-        plane, units, pixel_scale = self._FFT_output(focal_length)
+        plane, units, pixel_scale = self._FFT_output(pad, focal_length)
 
         # Pad must be int
         npixels = (self.npixels * (pad - 1)) // 2
@@ -776,7 +777,8 @@ class Wavefront(Base):
             The propagated wavefront.
         """
         # Calculate
-        plane, units, pixel_scale = self._FFT_output(focal_length, inverse=True)
+        plane, units, pixel_scale = self._FFT_output(pad, focal_length, 
+            inverse=True)
 
         # Pad must be int
         npixels = (self.npixels * (pad - 1)) // 2


### PR DESCRIPTION
Fixes a bug that resulted in the wrong pixel_scale output from `FFT`, as well as changing the default input for `focal_length` in `FFT` to None.