### PR TITLE
Jitter Classes (#249)

### DIFF
--- a/dLux/detector_layers.py
+++ b/dLux/detector_layers.py
@@ -139,7 +139,9 @@ class ApplyJitter(DetectorLayer):
 
         extent = self.kernel_size * pixel_scale
         x = np.linspace(0, extent, self.kernel_size) - 0.5 * extent
-        kernel = norm.pdf(x, scale=self.sigma) * norm.pdf(x[:, None], scale=self.sigma)
+        kernel = norm.pdf(x, scale=self.sigma) * norm.pdf(
+            x[:, None], scale=self.sigma
+        )
         return kernel / np.sum(kernel)
 
     def __call__(self: DetectorLayer, image: Image()) -> Image():

--- a/dLux/detector_layers.py
+++ b/dLux/detector_layers.py
@@ -166,8 +166,7 @@ class ApplyJitter(DetectorLayer):
             The covariance matrix.
         """
         # Compute the rotation angle
-        # the -'ve sign is simply so it rotates in a more intuitive direction
-        rot_angle = -np.radians(self.phi)
+        rot_angle = np.radians(self.phi)
 
         # Construct the rotation matrix
         R = np.array(

--- a/dLux/detector_layers.py
+++ b/dLux/detector_layers.py
@@ -136,10 +136,10 @@ class ApplyJitter(DetectorLayer):
         kernel : Array
             The Gaussian kernel.
         """
-        # Generate distribution
-        sigma = self.sigma * pixel_scale
-        x = np.linspace(-10, 10, self.kernel_size) * pixel_scale
-        kernel = norm.pdf(x, scale=sigma) * norm.pdf(x[:, None], scale=sigma)
+
+        extent = self.kernel_size * pixel_scale
+        x = np.linspace(0, extent, self.kernel_size) - 0.5 * extent
+        kernel = norm.pdf(x, scale=self.sigma) * norm.pdf(x[:, None], scale=self.sigma)
         return kernel / np.sum(kernel)
 
     def __call__(self: DetectorLayer, image: Image()) -> Image():

--- a/dLux/detector_layers.py
+++ b/dLux/detector_layers.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 from abc import abstractmethod
+import jax
 import jax.numpy as np
 from jax import Array
-from jax.scipy.stats import norm
+from jax.scipy.stats import norm, multivariate_normal
 from zodiax import Base
 import dLux
 
@@ -159,6 +160,119 @@ class ApplyJitter(DetectorLayer):
             The transformed image.
         """
         kernel = self.generate_kernel(image.pixel_scale)
+        return image.convolve(kernel)
+
+
+class ApplyAsymmetricJitter(DetectorLayer):
+    kernel_size: int
+    r: float = None
+    shear: float = None
+    phi: float = None
+
+    def __init__(
+        self: DetectorLayer,
+        r: float,
+        shear: float = 0,
+        phi: float = 0,
+        kernel_size: int = 10,
+    ):
+        """
+        Constructor for the ApplyJitter class.
+
+        Parameters
+        ----------
+        r : float, arcseconds
+            The magnitude of the jitter.
+        shear : float
+            The shear of the jitter.
+        phi : float, degrees
+            The angle of the jitter.
+        kernel_size : int = 10
+            The size of the convolution kernel in pixels to use.
+        """
+        super().__init__()
+        self.kernel_size = int(kernel_size)
+        self.r = r
+        self.shear = shear
+        self.phi = phi
+
+    @property
+    def covariance_matrix(self):
+        rot_angle = np.radians(self.phi) - np.pi / 4
+
+        # Construct the rotation matrix
+        rotation_matrix = np.array(
+            [
+                [np.cos(rot_angle), -np.sin(rot_angle)],
+                [np.sin(rot_angle), np.cos(rot_angle)],
+            ]
+        )
+
+        # Construct the skew matrix
+        skew_matrix = np.array(
+            [[1, self.shear], [self.shear, 1]]
+        )  # Ensure skew_matrix is symmetric
+
+        # Compute the covariance matrix
+        covariance_matrix = self.r * np.dot(
+            np.dot(rotation_matrix, skew_matrix), rotation_matrix.T
+        )
+
+        # Ensure positive semi-definiteness
+        try:
+            # Attempt Cholesky decomposition
+            jax.scipy.linalg.cholesky(covariance_matrix)
+            return covariance_matrix
+        except:
+            # TODO don't think this works
+            raise ValueError(
+                "Covariance matrix is not positive semi-definite."
+            )
+
+    def generate_kernel(self, pixel_scale: float) -> Array:
+        """
+        Generates the normalised Gaussian kernel.
+
+        Parameters
+        ----------
+        pixel_scale : float, arcsec/pixel
+            The pixel scale of the image.
+
+        Returns
+        -------
+        kernel : Array
+            The normalised Gaussian kernel.
+        """
+        # Generate distribution
+        extent = pixel_scale * self.kernel_size  # kernel size in arcseconds
+        x = np.linspace(0, extent, self.kernel_size) - 0.5 * extent
+        xs, ys = np.meshgrid(x, x)
+        pos = np.dstack((xs, ys))
+
+        kernel = multivariate_normal.pdf(
+            pos, mean=np.array([0.0, 0.0]), cov=self.covariance_matrix
+        )
+
+        return kernel / np.sum(kernel)
+
+    def __call__(self: DetectorLayer, image: Image()) -> Image():
+        """
+        Applies the layer to the Image.
+
+        Parameters
+        ----------
+        image : Image
+            The image to operate on.
+
+        Returns
+        -------
+        image : Image
+            The transformed image.
+        """
+        kernel = self.generate_kernel(
+            dl.utils.rad_to_arcsec(image.pixel_scale)
+        )
+
         return image.convolve(kernel)
 
 


### PR DESCRIPTION
PR to track changes.

Adding the `ApplyAsymmetricJitter` class I wrote for TOLIMAN, parametrised by `r`, `phi`, and `shear`.
I basically completely rewrote the `generate_kernel` method in a way that seems a bit more intuitive to me:

```python
    def generate_kernel(self, pixel_scale: float) -> Array:
        
        ...

        # Generate distribution
        extent = pixel_scale * self.kernel_size  # kernel size in arcseconds
        x = np.linspace(0, extent, self.kernel_size) - 0.5 * extent
        xs, ys = np.meshgrid(x, x)
        pos = np.dstack((xs, ys))

        kernel = multivariate_normal.pdf(
            pos, mean=np.array([0.0, 0.0]), cov=self.covariance_matrix
        )

        return kernel / np.sum(kernel)
```

I kinda reimplemented this way of generating the kernel into the original `ApplyJitter` detector class.

surely i become a real dLux contributor SURELY