### PR TITLE
added kwargs for psf.convolve

### DIFF
--- a/src/dLux/psfs.py
+++ b/src/dLux/psfs.py
@@ -79,7 +79,7 @@ class PSF(Base):
         """
         return self.set("data", dlu.downsample(self.data, n, mean=False))
 
-    def convolve(self: PSF, other: Array) -> PSF:
+    def convolve(self: PSF, other: Array, **kwargs) -> PSF:
         """
         Convolves the psf with some input array.
 
@@ -93,7 +93,9 @@ class PSF(Base):
         psf : PSF
             The convolved psf.
         """
-        return self.set("data", convolve(self.data, other, mode="same"))
+        return self.set(
+            "data", convolve(self.data, other, mode="same", **kwargs)
+        )
 
     def rotate(self: PSF, angle: float, order: int = 1) -> PSF:
         """

--- a/src/dLux/psfs.py
+++ b/src/dLux/psfs.py
@@ -79,7 +79,7 @@ class PSF(Base):
         """
         return self.set("data", dlu.downsample(self.data, n, mean=False))
 
-    def convolve(self: PSF, other: Array, method="auto") -> PSF:
+    def convolve(self: PSF, other: Array, method: str = "auto") -> PSF:
         """
         Convolves the psf with some input array.
 
@@ -88,7 +88,7 @@ class PSF(Base):
         other : Array
             The psf to convolve with.
         method : str = "auto"
-            The method to use for the convolution. Can be "auto", "direct", 
+            The method to use for the convolution. Can be "auto", "direct",
             or "fft". Is "auto" by default, which calls "direct".
 
         Returns

--- a/src/dLux/psfs.py
+++ b/src/dLux/psfs.py
@@ -79,7 +79,7 @@ class PSF(Base):
         """
         return self.set("data", dlu.downsample(self.data, n, mean=False))
 
-    def convolve(self: PSF, other: Array, **kwargs) -> PSF:
+    def convolve(self: PSF, other: Array, method="auto") -> PSF:
         """
         Convolves the psf with some input array.
 
@@ -87,6 +87,9 @@ class PSF(Base):
         ----------
         other : Array
             The psf to convolve with.
+        method : str = "auto"
+            The method to use for the convolution. Can be "auto", "direct", 
+            or "fft". Is "auto" by default, which calls "direct".
 
         Returns
         -------
@@ -94,7 +97,7 @@ class PSF(Base):
             The convolved psf.
         """
         return self.set(
-            "data", convolve(self.data, other, mode="same", **kwargs)
+            "data", convolve(self.data, other, mode="same", method=method)
         )
 
     def rotate(self: PSF, angle: float, order: int = 1) -> PSF:

--- a/tests/test_psfs.py
+++ b/tests/test_psfs.py
@@ -21,6 +21,7 @@ class TestPSF:
     def test_methods(self, psf):
         assert psf.downsample(2).npixels == 8
         assert isinstance(psf.convolve(np.ones((2, 2))), PSF)
+        assert isinstance(psf.convolve(np.ones((2, 2)), method="fft"), PSF)
         assert isinstance(psf.rotate(np.pi), PSF)
         assert isinstance(psf.resize(8), PSF)
         assert isinstance(psf.flip(0), PSF)


### PR DESCRIPTION
Allows for `"fft"` convolution method which is faster for medium-to-large arrays (thanks @ataras2)