### PR TITLE
incorrect likelihood

### DIFF
--- a/docs/tutorials/introductory/overview.md
+++ b/docs/tutorials/introductory/overview.md
@@ -260,7 +260,7 @@ data = jr.poisson(jr.PRNGKey(1), flux * optics.propagate(wavels))
 @zdx.filter_value_and_grad("aberrations.coefficients")
 def loss_fn(model, data):
     psf = flux * model.propagate(wavels)
-    return -jsp.stats.poisson.logpmf(data, psf).mean()
+    return -jsp.stats.poisson.logpmf(data, psf).sum()
 
 
 # Now we evaluate the loss function and get the gradients


### PR DESCRIPTION
Seems to be a bug in the docs here that Jonatan noticed - likelihood should be sum of loglikelihoods, not mean.

This will affect numerical values down the line