### PR TITLE
Atmospheric layers

### DIFF
--- a/src/dLux/layers/__init__.py
+++ b/src/dLux/layers/__init__.py
@@ -10,6 +10,7 @@ from . import (
     propagators,
     apertures,
     abcd_propagators,
+    atmospheres,
 )
 
 _modules = (
@@ -20,6 +21,7 @@ _modules = (
     propagators,
     apertures,
     abcd_propagators,
+    atmospheres,
 )
 
 _module_names = [
@@ -30,5 +32,6 @@ _module_names = [
     "propagators",
     "apertures",
     "abcd_propagators",
+    "atmospheres",
 ]
 __all__ = _module_names + reexport(_modules, globals())

--- a/src/dLux/layers/atmospheres.py
+++ b/src/dLux/layers/atmospheres.py
@@ -1,0 +1,355 @@
+"""JIT-compatible infinite von Kármán atmospheric phase screens."""
+
+import dLux.utils as dlu
+import equinox as eqx
+import interpax as ipx
+import jax
+import jax.numpy as np
+
+from .optical_layers import OpticalLayer
+from jax import Array
+
+__all__ = [
+    "AtmosphericLayer",
+    "InfiniteAtmosphericLayer",
+]
+
+
+class AtmosphericLayer(OpticalLayer):
+    """Base class for thin atmospheric OPD layers.
+
+    It owns the common physical metadata and the current screen state. Concrete
+    layers implement their own screen-generation and temporal-evolution models.
+    """
+
+    npixels: int = eqx.field(static=True)
+    pixel_scale: Array
+    Cn_squared: float
+    L0: float
+    velocity: Array
+    height: Array
+    coords: Array
+    base_opd: Array
+    screen: Array
+    center: Array
+    time: Array
+    key: Array
+
+    def __init__(self, npixels, pixel_scale, Cn_squared, L0, velocity=0, height=0):
+        if not isinstance(npixels, int) or npixels < 2:
+            raise ValueError("npixels must be an integer >= 2.")
+        if pixel_scale <= 0 or Cn_squared <= 0 or L0 <= 0:
+            raise ValueError("pixel_scale, Cn_squared, and L0 must be positive.")
+        velocity = np.asarray(velocity, float)
+        if velocity.ndim == 0:
+            velocity = np.array([velocity, 0.0])
+        if velocity.shape != (2,):
+            raise ValueError("velocity must be scalar or have shape (2,).")
+
+        self.npixels = npixels
+        self.pixel_scale = np.asarray(pixel_scale, float)
+        self.Cn_squared = np.asarray(Cn_squared, float)
+        self.L0 = np.asarray(L0, float)
+        self.velocity = velocity
+        self.height = np.asarray(height, float)
+        axis = (np.arange(npixels) - (npixels - 1) / 2) * self.pixel_scale
+        self.coords = np.stack((axis, axis))
+
+    def __call__(self, wavefront):
+        """Apply the current OPD without advancing the atmospheric state."""
+        return wavefront.add_opd(self.opd)
+
+
+class InfiniteAtmosphericLayer(AtmosphericLayer):
+    """Functional Assemat/Wilson/Gendron atmospheric layer.
+
+    Use ``opd, layer = layer.step(dt)``. The returned immutable layer can be
+    carried by ``jax.jit`` or ``jax.lax.scan``; calling it applies its current
+    OPD to a dLux wavefront without advancing time.
+    """
+
+    stencil_length: int = eqx.field(static=True)
+    use_interpolation: bool = eqx.field(static=True)
+    interpolation_method: str = eqx.field(static=True)
+    interpolation_kwargs: tuple = eqx.field(static=True)
+
+    initial_key: Array
+    stencils: tuple
+    A_matrices: tuple[Array]
+    B_matrices: tuple[Array]
+    high_filter: Array
+    low_basis: Array
+
+    def __init__(
+        self,
+        npixels,
+        pixel_scale,
+        Cn_squared,
+        L0,
+        velocity=0,
+        height=0,
+        stencil_length=2,
+        oversampling=16,
+        seed=0,
+        use_interpolation=True,
+        interpolation_method="linear",
+        **kwargs,
+    ):
+        AtmosphericLayer.__init__(
+            self, npixels, pixel_scale, Cn_squared, L0, velocity, height
+        )
+        if not isinstance(stencil_length, int) or not 1 <= stencil_length < npixels:
+            raise ValueError("stencil_length must be in [1, npixels).")
+        if not isinstance(oversampling, int) or oversampling < 1:
+            raise ValueError("oversampling must be a positive integer.")
+        self.stencil_length = stencil_length
+        self.use_interpolation = bool(use_interpolation)
+        self.interpolation_method = str(interpolation_method)
+        kwargs.pop("extrap", None)
+        self.interpolation_kwargs = tuple(sorted(kwargs.items()))
+        stencil_key, self.initial_key = jax.random.split(jax.random.PRNGKey(seed))
+        vk, hk = jax.random.split(stencil_key)
+        vertical_stencil, horizontal_stencil = self._stencil(vk, True), self._stencil(
+            hk, False
+        )
+        vertical_ab = self._ab(vertical_stencil, True)
+        horizontal_ab = self._ab(horizontal_stencil, False)
+        self.stencils = (vertical_stencil, horizontal_stencil)
+        self.A_matrices = (vertical_ab[0], horizontal_ab[0])
+        self.B_matrices = (vertical_ab[1], horizontal_ab[1])
+        self.high_filter, self.low_basis = self._spectral_model(oversampling)
+        self.base_opd, self.key = self._initial_screen(self.initial_key)
+        self.screen, self.center, self.time = (
+            self.base_opd,
+            np.zeros(2),
+            np.asarray(0.0),
+        )
+
+    def _stencil(self, key, vertical):
+        n, mask = self.npixels, np.zeros((self.npixels, self.npixels), bool)
+        random_points = (
+            jax.random.geometric(key, 0.5, (n,)) + self.stencil_length - 1
+        ) % n
+        if vertical:
+            mask = (
+                mask.at[: self.stencil_length, :]
+                .set(True)
+                .at[random_points, np.arange(n)]
+                .set(True)
+            )
+        else:
+            mask = (
+                mask.at[:, : self.stencil_length]
+                .set(True)
+                .at[np.arange(n), random_points]
+                .set(True)
+            )
+        return np.nonzero(mask.ravel(), size=int(mask.sum()), fill_value=0)[0]
+
+    def _ab(self, stencil, vertical):
+        yy, xx = np.meshgrid(self.coords[1], self.coords[0], indexing="ij")
+        if vertical:
+            nx, ny = self.coords[0], np.full(
+                self.npixels, self.coords[1][0] - self.pixel_scale
+            )
+        else:
+            nx, ny = (
+                np.full(self.npixels, self.coords[0][0] - self.pixel_scale),
+                self.coords[1],
+            )
+        px = np.concatenate((xx.ravel()[stencil], nx))
+        py = np.concatenate((yy.ravel()[stencil], ny))
+        cov = dlu.phase_covariance_von_karman(
+            dlu.fried_parameter_from_Cn_squared(1.0, 1.0), self.L0
+        )(np.stack((px[:, None] - px, py[:, None] - py)))
+        nz = stencil.shape[0]
+        zz, xz, zx, xx = cov[:nz, :nz], cov[nz:, :nz], cov[:nz, nz:], cov[nz:, nz:]
+        A = np.linalg.solve(zz + 1e-7 * np.eye(nz), xz.T).T
+        values, vectors = np.linalg.eigh((xx - A @ zx + (xx - A @ zx).T) / 2)
+        return A, vectors * np.sqrt(np.maximum(values, 0.0))[None]
+
+    def _spectral_model(self, oversampling):
+        n, df = self.npixels, 1 / (self.npixels * self.pixel_scale)
+        f = np.fft.fftfreq(n, self.pixel_scale)
+        fy, fx = np.meshgrid(f, f, indexing="ij")
+        r0 = dlu.fried_parameter_from_Cn_squared(self.Cn_squared, 1.0)
+        high = (
+            (
+                np.sqrt(
+                    dlu.power_spectral_density_von_karman(r0, self.L0)(
+                        np.stack((2 * np.pi * fx, 2 * np.pi * fy))
+                    )
+                    * df**2
+                )
+                * n**2
+            )
+            .at[0, 0]
+            .set(0.0)
+        )
+        modes = []
+        for level in range(1, max(1, int(np.ceil(np.log2(oversampling)))) + 1):
+            spacing = df / 2**level
+            modes += [
+                (i * spacing, j * spacing, spacing)
+                for j in (-1, 0, 1)
+                for i in (-1, 0, 1)
+                if i or j
+            ]
+        modes = np.asarray(modes)
+        phase = (
+            2
+            * np.pi
+            * (
+                modes[:, 0, None, None] * self.coords[0][None, None, :]
+                + modes[:, 1, None, None] * self.coords[1][None, :, None]
+            )
+        )
+        low_psd = dlu.power_spectral_density_von_karman(r0, self.L0)(
+            np.stack((2 * np.pi * modes[:, 0], 2 * np.pi * modes[:, 1]))
+        )
+        return high, np.sqrt(low_psd * modes[:, 2] ** 2)[:, None, None] * np.exp(
+            1j * phase
+        )
+
+    def _initial_screen(self, key):
+        high_key, low_key, next_key = jax.random.split(key, 3)
+        high = np.fft.ifft2(
+            jax.random.normal(high_key, (self.npixels, self.npixels)) * self.high_filter
+        ).real
+        low = np.real(
+            np.sum(
+                jax.random.normal(low_key, (self.low_basis.shape[0],))[:, None, None]
+                * self.low_basis,
+                axis=0,
+            )
+        )
+        return high + low, next_key
+
+    def _extrude(self, screen, key, horizontal, flipped):
+        stencil, A, B = (
+            (self.stencils[1], self.A_matrices[1], self.B_matrices[1])
+            if horizontal
+            else (self.stencils[0], self.A_matrices[0], self.B_matrices[0])
+        )
+        samples = screen.ravel()[self.npixels**2 - 1 - stencil if flipped else stencil]
+        key, noise_key = jax.random.split(key)
+        new = A @ samples + B @ jax.random.normal(noise_key, (B.shape[1],)) * np.sqrt(
+            self.Cn_squared
+        )
+        if horizontal:
+            extended = (
+                np.concatenate((screen[:, 1:], new[::-1, None]), 1)
+                if flipped
+                else np.concatenate((new[:, None], screen[:, :-1]), 1)
+            )
+        else:
+            extended = (
+                np.concatenate((screen[1:], new[None, ::-1]), 0)
+                if flipped
+                else np.concatenate((new[None], screen[:-1]), 0)
+            )
+        return extended, key
+
+    def _advance(self, screen, key, count, horizontal):
+        def body(state):
+            i, s, k = state
+            s, k = jax.lax.cond(
+                count < 0,
+                lambda a: self._extrude(*a, horizontal, False),
+                lambda a: self._extrude(*a, horizontal, True),
+                (s, k),
+            )
+            return i + 1, s, k
+
+        _, screen, key = jax.lax.while_loop(
+            lambda s: s[0] < np.abs(count), body, (np.asarray(0), screen, key)
+        )
+        return screen, key
+
+    def _sample(self, base, residual):
+        if not self.use_interpolation:
+            return base
+        if self.interpolation_method == "linear" and not self.interpolation_kwargs:
+            shift = residual / self.pixel_scale
+
+            def interpolate_axis(values, amount, axis):
+                positive = lambda value: np.concatenate(
+                    (
+                        jax.lax.slice_in_dim(value, 1, self.npixels, axis=axis),
+                        jax.lax.slice_in_dim(
+                            value, self.npixels - 1, self.npixels, axis=axis
+                        ),
+                    ),
+                    axis=axis,
+                )
+                negative = lambda value: np.concatenate(
+                    (
+                        jax.lax.slice_in_dim(value, 0, 1, axis=axis),
+                        jax.lax.slice_in_dim(value, 0, self.npixels - 1, axis=axis),
+                    ),
+                    axis=axis,
+                )
+                neighbor = jax.lax.cond(amount >= 0, positive, negative, values)
+                return values + np.abs(amount) * (neighbor - values)
+
+            shifted = interpolate_axis(base, shift[0], 1)
+            return interpolate_axis(shifted, shift[1], 0)
+
+        xq = np.clip(
+            self.coords[0][None] + residual[0], self.coords[0][0], self.coords[0][-1]
+        )
+        yq = np.clip(
+            self.coords[1][:, None] + residual[1], self.coords[1][0], self.coords[1][-1]
+        )
+        xx, yy = np.broadcast_arrays(xq, yq)
+        return ipx.interp2d(
+            yy.ravel(),
+            xx.ravel(),
+            self.coords[1],
+            self.coords[0],
+            base,
+            method=self.interpolation_method,
+            extrap=False,
+            **dict(self.interpolation_kwargs),
+        ).reshape(base.shape)
+
+    def step(self, dt):
+        dt = np.asarray(dt, self.time.dtype)
+        center = self.center + self.velocity * dt
+        before = np.round(self.center / self.pixel_scale).astype(int)
+        after = np.round(center / self.pixel_scale).astype(int)
+        base, key = self._advance(self.base_opd, self.key, after[0] - before[0], True)
+        base, key = self._advance(base, key, after[1] - before[1], False)
+        screen = self._sample(base, center - after * self.pixel_scale)
+        layer = eqx.tree_at(
+            lambda o: (o.base_opd, o.screen, o.center, o.time, o.key),
+            self,
+            (base, screen, center, self.time + dt, key),
+        )
+        return screen, layer
+
+    def evolve(self, dt, steps):
+        """Advance several frames inside one compiled loop.
+
+        This avoids dispatching one accelerator program per frame when only the
+        final screen and layer state are needed.
+        """
+        if not isinstance(steps, int) or steps < 0:
+            raise ValueError("steps must be a non-negative integer.")
+
+        layer = jax.lax.fori_loop(
+            0,
+            steps,
+            lambda _, state: state.step(dt)[1],
+            self,
+        )
+        return layer.screen, layer
+
+    def reset(self, independent=False):
+        base, key = self._initial_screen(self.key if independent else self.initial_key)
+        layer = eqx.tree_at(
+            lambda o: (o.base_opd, o.screen, o.center, o.time, o.key),
+            self,
+            (base, base, np.zeros_like(self.center), np.zeros_like(self.time), key),
+        )
+        return base, layer

--- a/src/dLux/utils/__init__.py
+++ b/src/dLux/utils/__init__.py
@@ -19,6 +19,8 @@ from . import (
     norms,
     apertures,
     fourier,
+    atmosphere,
+    bessel,
 )
 
 _modules = (
@@ -37,6 +39,8 @@ _modules = (
     norms,
     apertures,
     fourier,
+    atmosphere,
+    bessel,
 )
 
 _module_names = [
@@ -55,5 +59,7 @@ _module_names = [
     "norms",
     "apertures",
     "fourier",
+    "atmosphere",
+    "bessel",
 ]
 __all__ = _module_names + reexport(_modules, globals())

--- a/src/dLux/utils/atmosphere.py
+++ b/src/dLux/utils/atmosphere.py
@@ -1,0 +1,74 @@
+"""
+Atmospheric turbulence models and related functions.
+Adapted from hcipy (https://github.com/ehpor/hcipy)
+"""
+
+import jax
+import jax.numpy as np
+
+from .bessel import kv
+
+__all__ = [
+    "Cn_squared_from_fried_parameter",
+    "fried_parameter_from_Cn_squared",
+    "phase_covariance_von_karman",
+    "phase_structure_function_von_karman",
+    "power_spectral_density_von_karman",
+]
+
+
+def fried_parameter_from_Cn_squared(cn2, wavelength=500e-9):
+    return (0.423 * cn2 * (2 * np.pi / wavelength) ** 2) ** (-3 / 5)
+
+
+def Cn_squared_from_fried_parameter(r0, wavelength=500e-9):
+    return r0 ** (-5 / 3) / (0.423 * (2 * np.pi / wavelength) ** 2)
+
+
+def phase_covariance_von_karman(r0, L0):
+    def covariance(coords):
+        radius = np.maximum(np.hypot(coords[0], coords[1]), 1e-10)
+        z = 2 * np.pi * radius / L0
+        return (
+            (L0 / r0) ** (5 / 3)
+            * jax.scipy.special.gamma(11 / 6)
+            / (2 ** (5 / 6) * np.pi ** (8 / 3))
+            * (24 / 5 * jax.scipy.special.gamma(6 / 5)) ** (5 / 6)
+            * z ** (5 / 6)
+            * kv(5 / 6, z)
+        )
+
+    return covariance
+
+
+def phase_structure_function_von_karman(r0, L0):
+    def structure(coords):
+        radius = np.hypot(coords[0], coords[1])
+        z = 2 * np.pi * np.maximum(radius, 1e-10) / L0
+        result = (
+            (L0 / r0) ** (5 / 3)
+            * 2 ** (1 / 6)
+            * jax.scipy.special.gamma(11 / 6)
+            / np.pi ** (8 / 3)
+            * (24 / 5 * jax.scipy.special.gamma(6 / 5)) ** (5 / 6)
+            * (
+                jax.scipy.special.gamma(5 / 6) / 2 ** (1 / 6)
+                - z ** (5 / 6) * kv(5 / 6, z)
+            )
+        )
+        return np.where(radius == 0, 0.0, result)
+
+    return structure
+
+
+def power_spectral_density_von_karman(r0, L0):
+    def psd(coords):
+        u = np.hypot(coords[0], coords[1])
+
+        return (
+            0.0229
+            * ((u**2 + (2 * np.pi / L0) ** 2) / (2 * np.pi) ** 2) ** (-11 / 6)
+            * r0 ** (-5 / 3)
+        )
+
+    return psd

--- a/src/dLux/utils/bessel.py
+++ b/src/dLux/utils/bessel.py
@@ -1,0 +1,466 @@
+"""
+Yoinked from JAX-GalSim
+"""
+
+import jax
+import jax.numpy as np
+
+# =====================================================================
+# Modified Bessel K_v(x)
+#
+# The functions below (_sqrt1px2, _evaluate_temme_coeffs,
+# _temme_series_kve, _continued_fraction_kve, _olver_kve, _temme_kve,
+# _kve_core) and the _ASYMPTOTIC_OLVER_COEFFICIENTS constant are
+# derived from TensorFlow Probability's bessel.py:
+#   https://github.com/tensorflow/probability
+#
+# Original copyright and license:
+#   Copyright 2020 The TensorFlow Probability Authors.
+#   Licensed under the Apache License, Version 2.0.
+#
+# Modifications from the original:
+#   - Ported from TensorFlow/TFP APIs to pure JAX (jax.numpy, jax.lax)
+#   - Removed I_v (bessel_ive) computation; only K_v is computed
+#   - Removed log-space output option
+#   - Removed negative-v correction for I_v
+#   - Simplified to scalar-only core (vectorization via jax.vmap)
+# =====================================================================
+
+# Olver expansion polynomial coefficients (10 terms, up to 31 coefficients each)
+# fmt: off
+_ASYMPTOTIC_OLVER_COEFFICIENTS = [
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     -0.20833333333333334, 0., 0.125, 0.],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     0., 0., 0., 0., 0., 0., 0., 0., 0., 0.3342013888888889, 0.,
+     -0.40104166666666669, 0., 0.0703125, 0., 0.0],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     0., 0., 0., 0., 0., 0., -1.0258125964506173, 0., 1.8464626736111112,
+     0., -0.89121093750000002, 0., 0.0732421875, 0., 0., 0.],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     0., 0., 0., 4.6695844234262474, 0., -11.207002616222995, 0.,
+     8.78912353515625, 0., -2.3640869140624998, 0., 0.112152099609375,
+     0., 0., 0., 0.],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
+     -28.212072558200244, 0., 84.636217674600744, 0., -91.818241543240035,
+     0., 42.534998745388457, 0., -7.3687943594796312, 0., 0.22710800170898438,
+     0., 0., 0., 0., 0.],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 212.5701300392171, 0.,
+     -765.25246814118157, 0., 1059.9904525279999, 0., -699.57962737613275,
+     0., 218.19051174421159, 0., -26.491430486951554, 0., 0.57250142097473145,
+     0., 0., 0., 0., 0., 0.],
+    [0., 0., 0., 0., 0., 0., 0., 0., 0., -1919.4576623184068, 0.,
+     8061.7221817373083, 0., -13586.550006434136, 0., 11655.393336864536,
+     0., -5305.6469786134048, 0., 1200.9029132163525, 0.,
+     -108.09091978839464, 0., 1.7277275025844574, 0., 0., 0., 0., 0., 0., 0.],
+    [0., 0., 0., 0., 0., 0., 20204.291330966149, 0., -96980.598388637503, 0.,
+     192547.0012325315, 0., -203400.17728041555, 0., 122200.46498301747,
+     0., -41192.654968897557, 0., 7109.5143024893641, 0.,
+     -493.915304773088, 0., 6.074042001273483, 0., 0., 0., 0., 0.,
+     0., 0., 0.],
+    [0., 0., 0., -242919.18790055133, 0., 1311763.6146629769, 0.,
+     -2998015.9185381061, 0., 3763271.2976564039, 0., -2813563.2265865342, 0.,
+     1268365.2733216248, 0., -331645.17248456361, 0., 45218.768981362737, 0.,
+     -2499.8304818112092, 0., 24.380529699556064, 0., 0., 0., 0., 0.,
+     0., 0., 0., 0.0],
+    [3284469.8530720375, 0., -19706819.11843222, 0., 50952602.492664628,
+     0., -74105148.211532637, 0., 66344512.274729028, 0., -37567176.660763353,
+     0., 13288767.166421819, 0., -2785618.1280864552, 0., 308186.40461266245,
+     0., -13886.089753717039, 0., 110.01714026924674, 0., 0., 0., 0., 0.,
+     0., 0., 0., 0., 0.]
+]
+# fmt: on
+
+
+def _sqrt1px2(x):
+    """Numerically stable computation of sqrt(1 + x^2)."""
+    eps = np.finfo(x.dtype).eps
+    return np.where(
+        np.abs(x) * np.sqrt(eps) <= 1.0,
+        np.exp(0.5 * np.log1p(x * x)),
+        np.abs(x),
+    )
+
+
+def _evaluate_temme_coeffs(v):
+    """Numerically stable computation of gamma-related coefficients for Temme's method.
+
+    Computes:
+      coeff1 = (1/Gamma(1-v) - 1/Gamma(1+v)) / (2v)
+      coeff2 = (1/Gamma(1-v) + 1/Gamma(1+v)) / 2
+      gamma1pv = 1/Gamma(1+v)
+      gamma1mv = 1/Gamma(1-v)
+
+    Uses Chebyshev expansions for numerical stability (avoids catastrophic cancellation).
+    """
+    coeff1_coeffs = [
+        -1.142022680371168e0,
+        6.5165112670737e-3,
+        3.087090173086e-4,
+        -3.4706269649e-6,
+        6.9437664e-9,
+        3.67795e-11,
+        -1.356e-13,
+    ]
+    coeff2_coeffs = [
+        1.843740587300905e0,
+        -7.68528408447867e-2,
+        1.2719271366546e-3,
+        -4.9717367042e-6,
+        -3.31261198e-8,
+        2.423096e-10,
+        -1.702e-13,
+        -1.49e-15,
+    ]
+    w = 8.0 * v * v - 1.0
+    y = 2.0 * w
+
+    # Clenshaw's recurrence for coeff1
+    prev = 0.0
+    current = 0.0
+    for i in reversed(range(1, len(coeff1_coeffs))):
+        temp = current
+        current = y * current - prev + coeff1_coeffs[i]
+        prev = temp
+    coeff1 = w * current - prev + 0.5 * coeff1_coeffs[0]
+
+    # Clenshaw's recurrence for coeff2
+    prev = 0.0
+    current = 0.0
+    for i in reversed(range(1, len(coeff2_coeffs))):
+        temp = current
+        current = y * current - prev + coeff2_coeffs[i]
+        prev = temp
+    coeff2 = w * current - prev + 0.5 * coeff2_coeffs[0]
+
+    gamma1pv = coeff2 - v * coeff1
+    gamma1mv = coeff2 + v * coeff1
+    return coeff1, coeff2, gamma1pv, gamma1mv
+
+
+def _temme_series_kve(v, z):
+    """Compute Kve(v, z) and Kve(v+1, z) via Temme power series.
+
+    Assumes |v| < 0.5 and |z| <= 2 for fast convergence.
+    Returns exponentially scaled values: Kv(v,z)*exp(z).
+    """
+    tol = np.finfo(z.dtype).eps
+
+    coeff1, coeff2, gamma1pv_inv, gamma1mv_inv = _evaluate_temme_coeffs(v)
+
+    z_sq = z * z
+    logzo2 = np.log(z / 2.0)
+    mu = -v * logzo2
+    sinc_v = np.sinc(v)
+    mu_msk = np.where(mu == 0.0, 1.0, mu)
+    sinhc_mu = np.where(mu == 0.0, 1.0, np.sinh(mu_msk) / mu_msk)
+
+    initial_f = (coeff1 * np.cosh(mu) + coeff2 * (-logzo2) * sinhc_mu) / sinc_v
+    initial_p = 0.5 * np.exp(mu) / gamma1pv_inv
+    initial_q = 0.5 * np.exp(-mu) / gamma1mv_inv
+
+    max_iterations = 1000
+
+    def body_fn(carry):
+        should_stop, index, f, p, q, coeff, kv_sum, kvp1_sum = carry
+        f = np.where(
+            should_stop,
+            f,
+            (index * f + p + q) / (index * index - v * v),
+        )
+        p = np.where(should_stop, p, p / (index - v))
+        q = np.where(should_stop, q, q / (index + v))
+        h = p - index * f
+        coeff = np.where(should_stop, coeff, coeff * z_sq / (4.0 * index))
+        kv_sum = np.where(should_stop, kv_sum, kv_sum + coeff * f)
+        kvp1_sum = np.where(should_stop, kvp1_sum, kvp1_sum + coeff * h)
+        index = index + 1.0
+        should_stop = (np.abs(coeff * f) < np.abs(kv_sum) * tol) | (
+            index > max_iterations
+        )
+        return (should_stop, index, f, p, q, coeff, kv_sum, kvp1_sum)
+
+    def cond_fn(carry):
+        should_stop = carry[0]
+        return ~should_stop
+
+    init = (
+        np.array(False),
+        1.0,
+        initial_f,
+        initial_p,
+        initial_q,
+        1.0,
+        initial_f,
+        initial_p,
+    )
+    _, _, _, _, _, _, kv_sum, kvp1_sum = jax.lax.while_loop(cond_fn, body_fn, init)
+
+    # Convert to exponentially scaled: kve = kv * exp(z)
+    kve = kv_sum * np.exp(z)
+    kvep1 = 2.0 * kvp1_sum * np.exp(z) / z
+
+    return kve, kvep1
+
+
+def _continued_fraction_kve(v, z):
+    """Compute Kve(v, z) and Kve(v+1, z) via Steed's continued fraction.
+
+    Assumes |v| < 0.5 and |z| > 2.
+    Returns exponentially scaled values: Kv(v,z)*exp(z).
+    """
+    tol = np.finfo(z.dtype).eps
+    max_iterations = 1000
+
+    initial_numerator = v * v - 0.25
+    initial_denominator = 2.0 * (z + 1.0)
+    initial_ratio = 1.0 / initial_denominator
+    initial_seq = -initial_numerator
+
+    def steeds_body(carry):
+        (
+            should_stop,
+            index,
+            partial_numerator,
+            partial_denominator,
+            denominator_ratio,
+            convergent_difference,
+            hypergeometric_ratio,
+            k_0,
+            k_1,
+            c,
+            q,
+            hypergeometric_sum,
+        ) = carry
+
+        partial_numerator = partial_numerator - 2.0 * (index - 1.0)
+        c = np.where(should_stop, c, -c * partial_numerator / index)
+        next_k = (k_0 - partial_denominator * k_1) / partial_numerator
+        k_0 = np.where(should_stop, k_0, k_1)
+        k_1 = np.where(should_stop, k_1, next_k)
+        q = np.where(should_stop, q, q + c * next_k)
+        partial_denominator = partial_denominator + 2.0
+        denominator_ratio = 1.0 / (
+            partial_denominator + partial_numerator * denominator_ratio
+        )
+        convergent_difference = np.where(
+            should_stop,
+            convergent_difference,
+            convergent_difference * (partial_denominator * denominator_ratio - 1.0),
+        )
+        hypergeometric_ratio = np.where(
+            should_stop,
+            hypergeometric_ratio,
+            hypergeometric_ratio + convergent_difference,
+        )
+        hypergeometric_sum = np.where(
+            should_stop,
+            hypergeometric_sum,
+            hypergeometric_sum + q * convergent_difference,
+        )
+        index = index + 1.0
+        should_stop = (
+            np.abs(q * convergent_difference) < np.abs(hypergeometric_sum) * tol
+        ) | (index > max_iterations)
+        return (
+            should_stop,
+            index,
+            partial_numerator,
+            partial_denominator,
+            denominator_ratio,
+            convergent_difference,
+            hypergeometric_ratio,
+            k_0,
+            k_1,
+            c,
+            q,
+            hypergeometric_sum,
+        )
+
+    def cond_fn(carry):
+        return ~carry[0]
+
+    init = (
+        np.array(False),
+        2.0,
+        initial_numerator,
+        initial_denominator,
+        initial_ratio,
+        initial_ratio,
+        initial_ratio,
+        0.0,
+        1.0,
+        initial_seq,
+        initial_seq,
+        1.0 - initial_numerator * initial_ratio,
+    )
+    result = jax.lax.while_loop(cond_fn, steeds_body, init)
+    hypergeometric_ratio = result[6]
+    hypergeometric_sum = result[11]
+
+    # log(kve) = 0.5*log(pi/(2z)) - log(hypergeometric_sum)
+    log_kve = 0.5 * np.log(np.pi / (2.0 * z)) - np.log(hypergeometric_sum)
+    log_kvp1e = (
+        log_kve
+        + np.log1p(2.0 * (v + z + initial_numerator * hypergeometric_ratio))
+        - np.log(z)
+        - np.log(2.0)
+    )
+    return np.exp(log_kve), np.exp(log_kvp1e)
+
+
+def _olver_kve(v, z):
+    """Compute Kve(v, z) using Olver's uniform asymptotic expansion.
+
+    Valid for |v| >= 50. Returns exponentially scaled value: Kv(v,z)*exp(z).
+    """
+    v_abs = np.abs(v)
+    w = z / v_abs
+    t = 1.0 / _sqrt1px2(w)
+
+    divisor = v_abs
+    kve_sum = 1.0
+
+    # Evaluate the Olver polynomial terms using Horner's method
+    for i in range(len(_ASYMPTOTIC_OLVER_COEFFICIENTS)):
+        coeff = 0.0
+        for c in _ASYMPTOTIC_OLVER_COEFFICIENTS[i]:
+            coeff = coeff * t + c
+        term = coeff / divisor
+        # For K_v, signs alternate: (-1)^i
+        kve_sum = kve_sum + (term if i % 2 == 1 else -term)
+        divisor = divisor * v_abs
+
+    # log(kve) = 0.5*log(pi*t/(2*v_abs)) - v_abs*shared_prefactor
+    shared_prefactor = 1.0 / (_sqrt1px2(w) + w) + np.log(w) - np.log1p(1.0 / t)
+    log_k_prefactor = 0.5 * np.log(np.pi * t / (2.0 * v_abs)) - v_abs * shared_prefactor
+
+    log_kve = log_k_prefactor + np.log(kve_sum)
+    return np.exp(log_kve)
+
+
+def _temme_kve(v, x):
+    """Compute Kve(v, x) using Temme's method for |v| < 50.
+
+    Reduces to fractional order |u| <= 0.5, computes Kve(u, x) and Kve(u+1, x),
+    then uses forward recurrence to reach order v.
+    Returns exponentially scaled value: Kv(v,x)*exp(x).
+    """
+    v = np.abs(v)
+    n = np.round(v)
+    u = v - n
+
+    # Branchless: compute both methods with safe inputs, select with np.where
+    small_x = np.where(x <= 2.0, x, 0.1)
+    large_x = np.where(x > 2.0, x, 1000.0)
+
+    temme_kue, temme_kuep1 = _temme_series_kve(u, small_x)
+    cf_kue, cf_kuep1 = _continued_fraction_kve(u, large_x)
+
+    kue = np.where(x <= 2.0, temme_kue, cf_kue)
+    kuep1 = np.where(x <= 2.0, temme_kuep1, cf_kuep1)
+
+    # Forward recurrence: K_{v+1}(z) = (2v/z)*K_v(z) + K_{v-1}(z)
+    # This recurrence is also satisfied by Kv*exp(z) (the exponentially scaled form).
+    def bessel_recurrence(carry):
+        index, kve, kvep1 = carry
+        next_kvep1 = 2.0 * (u + index) * kvep1 / x + kve
+        kve = np.where(index > n, kve, kvep1)
+        kvep1 = np.where(index > n, kvep1, next_kvep1)
+        return (index + 1.0, kve, kvep1)
+
+    def recurrence_cond(carry):
+        index = carry[0]
+        return index <= n
+
+    _, kve, _ = jax.lax.while_loop(
+        recurrence_cond, bessel_recurrence, (1.0, kue, kuep1)
+    )
+    return kve
+
+
+def _kve_core(nu, x):
+    """Core dispatcher for Kve(nu, x) = Kv(nu, x) * exp(x).
+
+    Branchless: computes both Olver and Temme with safe dummy inputs,
+    selects based on |nu| >= 50.
+    """
+    nu = np.abs(nu)
+
+    # Safe inputs: avoid invalid regions for each method
+    small_nu = np.where(nu < 50.0, nu, 0.1)
+    large_nu = np.where(nu >= 50.0, nu, 1000.0)
+
+    olver_result = _olver_kve(large_nu, x)
+    temme_result = _temme_kve(small_nu, x)
+
+    return np.where(nu >= 50.0, olver_result, temme_result)
+
+
+def _kv_scalar(nu, x):
+    """Scalar implementation of K_v(x) using TFP-ported Temme + Olver algorithms."""
+    nu = 1.0 * nu
+    x = 1.0 * x
+    nu = np.abs(nu)  # K_{-v} = K_v
+
+    # Compute via exponentially scaled form for numerical stability
+    # Use a safe x for the core computation (avoid x=0 which causes issues)
+    safe_x = np.where(x > 0.0, x, 1.0)
+    kve = _kve_core(nu, safe_x)
+    result = kve * np.exp(-safe_x)
+
+    # Edge cases
+    result = np.where(x == 0.0, np.inf, result)
+    result = np.where(x < 0.0, np.nan, result)
+    return result
+
+
+@jax.jit
+def _kv_impl(nu, x):
+    """Modified Bessel function of the second kind K_v(x) - internal implementation.
+
+    Uses TFP-ported Temme + Olver algorithms for all orders.
+    Handles both scalar and array inputs via jax.vmap.
+    """
+    nu = np.asarray(1.0 * nu)
+    x = np.asarray(1.0 * x)
+    out_shape = np.broadcast_shapes(np.shape(nu), np.shape(x))
+    if out_shape == ():
+        return _kv_scalar(nu, x)
+    nu_bc, x_bc = np.broadcast_arrays(nu, x)
+    flat_nu = nu_bc.ravel()
+    flat_x = x_bc.ravel()
+    return jax.vmap(_kv_scalar)(flat_nu, flat_x).reshape(out_shape)
+
+
+@jax.custom_vjp
+def kv(nu, x):
+    """Modified Bessel function of the second kind K_v(x) with custom gradients.
+
+    Uses TFP-ported Temme + Olver algorithms. Custom gradients via:
+        dK_v/dx = -1/2 * (K_{v-1}(x) + K_{v+1}(x))
+
+    Gradient w.r.t. v is not supported (returns zero).
+    """
+    return _kv_impl(nu, x)
+
+
+def _kv_fwd(nu, x):
+    kv_val = _kv_impl(nu, x)
+    kv_prev = _kv_impl(nu - 1.0, x)
+    kv_next = _kv_impl(nu + 1.0, x)
+    return kv_val, (nu, x, kv_prev, kv_next)
+
+
+def _kv_bwd(residuals, g):
+    nu, x, kv_prev, kv_next = residuals
+    grad_x = -0.5 * (kv_prev + kv_next) * g
+    grad_nu = np.zeros_like(nu)
+    return (grad_nu, grad_x)
+
+
+kv.defvjp(_kv_fwd, _kv_bwd)
+
+
+kv(5 / 6, 2 * np.pi * 1.0)  # Example usage

--- a/tests/layers/test_atmopsheres.py
+++ b/tests/layers/test_atmopsheres.py
@@ -1,0 +1,87 @@
+import jax.numpy as np
+import pytest
+
+from dLux.layers import InfiniteAtmosphericLayer
+
+
+@pytest.fixture(scope="module")
+def layer():
+    return InfiniteAtmosphericLayer(
+        npixels=4,
+        pixel_scale=0.1,
+        Cn_squared=1.0,
+        L0=10.0,
+        velocity=np.array([0.4, -0.2]),
+        stencil_length=1,
+        oversampling=1,
+        seed=0,
+    )
+
+
+def test_initial_state(layer):
+    assert layer.screen.shape == (4, 4)
+    assert layer.base_opd.shape == (4, 4)
+    assert layer.coords.shape == (2, 4)
+    assert np.all(np.isfinite(layer.screen))
+    assert np.allclose(layer.center, 0)
+    assert np.allclose(layer.time, 0)
+
+
+def test_step_advances_state_without_mutating_original(layer):
+    screen, advanced = layer.step(0.5)
+
+    assert screen.shape == layer.screen.shape
+    assert np.allclose(screen, advanced.screen)
+    assert np.allclose(advanced.center, np.array([0.2, -0.1]))
+    assert np.allclose(advanced.time, 0.5)
+    assert np.allclose(layer.center, 0)
+    assert np.allclose(layer.time, 0)
+
+
+def test_evolve_matches_repeated_steps(layer):
+    _, first = layer.step(0.25)
+    expected_screen, expected_layer = first.step(0.25)
+
+    screen, evolved = layer.evolve(0.25, 2)
+
+    assert np.allclose(screen, expected_screen)
+    assert np.allclose(evolved.screen, expected_layer.screen)
+    assert np.allclose(evolved.center, expected_layer.center)
+    assert np.allclose(evolved.time, expected_layer.time)
+
+
+def test_reset_restores_initial_state(layer):
+    _, advanced = layer.step(0.5)
+    screen, reset = advanced.reset()
+
+    assert np.allclose(screen, layer.screen)
+    assert np.allclose(reset.screen, layer.screen)
+    assert np.allclose(reset.center, 0)
+    assert np.allclose(reset.time, 0)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"npixels": 1}, "npixels"),
+        ({"pixel_scale": 0}, "positive"),
+        ({"Cn_squared": 0}, "positive"),
+        ({"L0": 0}, "positive"),
+        ({"velocity": [1, 2, 3]}, "velocity"),
+        ({"stencil_length": 4}, "stencil_length"),
+        ({"oversampling": 0}, "oversampling"),
+    ],
+)
+def test_invalid_parameters(overrides, message):
+    parameters = {
+        "npixels": 4,
+        "pixel_scale": 0.1,
+        "Cn_squared": 1.0,
+        "L0": 10.0,
+        "stencil_length": 1,
+        "oversampling": 1,
+    }
+    parameters.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        InfiniteAtmosphericLayer(**parameters)


### PR DESCRIPTION
A quick (and rough around the edges) jax/zodiax version of `hcipy`'s `InfiniteAtmosphericLayer`, which implements Assemat et al. 2006. Suggestion to try this from @ehpor. Preliminary results on my machine show
- ~5 screens per second in native hcipy
- ~190 screens/s on cpu, jitted dLux
- ~1000 screens/s on gpu, jitted dLux

This PR is important for ground based adaptive optics simulations.

Key features:
- Use ``opd, layer = layer.step(dt)``.
- The returned immutable layer can be carried by ``jax.jit`` or ``jax.lax.scan``
- calling it applies its current OPD to a dLux wavefront without advancing time.

Future work (maybe in scope of PR):
- `LayeredAtmosphere`, with different heights and fresnel propagation
- a finite version that wraps, which might deal better with larger outer scales

Note the `atmo` branch was started off the polarisation branch... and should be deleted for ease of merge. This is the correct branch.